### PR TITLE
BeMain/issue22

### DIFF
--- a/lib/current_race_screen/car_viewer.dart
+++ b/lib/current_race_screen/car_viewer.dart
@@ -24,8 +24,9 @@ class CarViewer extends StatelessWidget {
             children: docs.map((lapSnap) {
               Lap lap = lapSnap.data();
               return TextTile(
-                  title: "${lap.lapNumber} | ${lap.lapTime}s",
-                  text: dateString((lap.date).toDate()),
+                  title:
+                      "${lap.lapNumber} | ${lap.lapTime.inMilliseconds / 1000}s",
+                  text: dateString((lap.date)),
                   onTap: () => Navigator.of(context).push(
                         MaterialPageRoute(
                           builder: (c) => (LapViewerScreen(

--- a/lib/current_race_screen/current_race_screen.dart
+++ b/lib/current_race_screen/current_race_screen.dart
@@ -36,10 +36,10 @@ class CurrentRaceScreenState extends State<CurrentRaceScreen> {
                     // Stop race
                     showNewDialog(context);
                   } else {
-                    Timestamp timeNow = Timestamp.now();
+                    DateTime timeNow = DateTime.now();
                     // Start race
                     Races.currentRaceDoc.update({
-                      "date": timeNow,
+                      "date": Timestamp.fromDate(timeNow),
                       "running": true,
                     });
                     for (CarReference car in Races.currentRaceRef.carRefs) {

--- a/lib/firebase/car_reference.dart
+++ b/lib/firebase/car_reference.dart
@@ -14,7 +14,11 @@ class CarReference {
         );
 
   /// The current lap for the car that [this] references.
-  Lap currentLap = Lap(date: Timestamp.now(), lapNumber: 1, lapTime: 0);
+  Lap currentLap = Lap(
+    date: DateTime.now(),
+    lapNumber: 1,
+    lapTime: const Duration(),
+  );
 
   /// The snapshots of all the laps currently on the database.
   Future<List<DocumentSnapshot<Lap>>> getLapDocs() async {
@@ -33,6 +37,10 @@ class CarReference {
       await lap.reference.delete();
     }
     // Reset current lap
-    currentLap = Lap(date: Timestamp.now(), lapNumber: 1, lapTime: 0);
+    currentLap = Lap(
+      date: DateTime.now(),
+      lapNumber: 1,
+      lapTime: const Duration(),
+    );
   }
 }

--- a/lib/firebase/lap.dart
+++ b/lib/firebase/lap.dart
@@ -25,7 +25,7 @@ class Lap {
   Lap.fromJson(Map<String, dynamic> json)
       : this(
           date: json["date"].toDate(),
-          lapTime: Duration(milliseconds: (json["lapTime"] * 1000).toInt()),
+          lapTime: Duration(milliseconds: json["lapTime"].toInt()),
           lapNumber: json["lapNumber"],
           speedHistory: Map<String, dynamic>.of(json["speedHistory"] ?? {})
               .entries
@@ -35,7 +35,7 @@ class Lap {
 
   Map<String, dynamic> toJson() => {
         "date": Timestamp.fromDate(date),
-        "lapTime": lapTime.inMilliseconds / 1000,
+        "lapTime": lapTime.inMilliseconds,
         "lapNumber": lapNumber,
         "speedHistory": Map.fromEntries(
           speedHistory.map((entry) => entry.toMapEntry()),

--- a/lib/firebase/lap.dart
+++ b/lib/firebase/lap.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:marklin_bluetooth/firebase/speed_entry.dart';
 
 class Lap {
   /// When this lap was started.
@@ -12,29 +13,32 @@ class Lap {
   /// How the speed has varied during [this] lap
   /// The key is the time since [this] lap was started,
   /// and the value is the speed at that time.
-  Map<int, double> speedHistory;
+  List<SpeedEntry> speedHistory;
 
   Lap({
     required this.date,
     required this.lapTime,
     required this.lapNumber,
-    speedHistory,
-  }) : speedHistory = speedHistory ?? {};
+    List<SpeedEntry>? speedHistory,
+  }) : speedHistory = speedHistory ?? [];
 
   Lap.fromJson(Map<String, dynamic> json)
       : this(
           date: json["date"],
           lapTime: json["lapTime"].toDouble(),
           lapNumber: json["lapNumber"],
-          speedHistory: Map.from(json["speedHistory"] ?? {})
-              .map((k, v) => MapEntry<int, double>(int.parse(k), v)),
+          speedHistory: Map<String, dynamic>.of(json["speedHistory"] ?? {})
+              .entries
+              .map((e) => SpeedEntry.fromMapEntry(e))
+              .toList(),
         );
 
   Map<String, dynamic> toJson() => {
         "date": date,
         "lapTime": lapTime,
         "lapNumber": lapNumber,
-        "speedHistory": Map.from(speedHistory)
-            .map((k, v) => MapEntry<String, dynamic>("$k", v)),
+        "speedHistory": Map.fromEntries(
+          speedHistory.map((entry) => entry.toMapEntry()),
+        ),
       };
 }

--- a/lib/firebase/lap.dart
+++ b/lib/firebase/lap.dart
@@ -3,10 +3,10 @@ import 'package:marklin_bluetooth/firebase/speed_entry.dart';
 
 class Lap {
   /// When this lap was started.
-  Timestamp date;
+  DateTime date;
 
   /// The time this lap took to complete, in seconds.
-  double lapTime;
+  Duration lapTime;
 
   int lapNumber;
 
@@ -24,8 +24,8 @@ class Lap {
 
   Lap.fromJson(Map<String, dynamic> json)
       : this(
-          date: json["date"],
-          lapTime: json["lapTime"].toDouble(),
+          date: json["date"].toDate(),
+          lapTime: Duration(milliseconds: (json["lapTime"] * 1000).toInt()),
           lapNumber: json["lapNumber"],
           speedHistory: Map<String, dynamic>.of(json["speedHistory"] ?? {})
               .entries
@@ -34,8 +34,8 @@ class Lap {
         );
 
   Map<String, dynamic> toJson() => {
-        "date": date,
-        "lapTime": lapTime,
+        "date": Timestamp.fromDate(date),
+        "lapTime": lapTime.inMilliseconds / 1000,
         "lapNumber": lapNumber,
         "speedHistory": Map.fromEntries(
           speedHistory.map((entry) => entry.toMapEntry()),

--- a/lib/firebase/race_reference.dart
+++ b/lib/firebase/race_reference.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:marklin_bluetooth/firebase/car_reference.dart';
 import 'package:marklin_bluetooth/firebase/race.dart';
+import 'package:marklin_bluetooth/firebase/speed_entry.dart';
 
 /// Helper class for interacting with a Race on the database.
 class RaceReference {
@@ -61,10 +62,9 @@ class RaceReference {
 
     CarReference car = carRef(carID);
 
-    int relTime = Timestamp.now().millisecondsSinceEpoch -
-        car.currentLap.date.millisecondsSinceEpoch;
+    Duration relTime = DateTime.now().difference(car.currentLap.date.toDate());
 
-    car.currentLap.speedHistory.addEntries([MapEntry(relTime, speed)]);
+    car.currentLap.speedHistory.add(SpeedEntry(relTime, speed));
   }
 
   /// Delete all laps on [this.race].

--- a/lib/firebase/race_reference.dart
+++ b/lib/firebase/race_reference.dart
@@ -30,19 +30,16 @@ class RaceReference {
 
   /// Add time since current lap to lap times of [carID] on [this.race],
   /// if current lap exists.
-  Future<void> addLap(int carID, {double? lapTime, int? lapN}) async {
+  Future<void> addLap(int carID, {Duration? lapTime, int? lapN}) async {
     Race race = await this.race;
     if (!race.running) return; // Not running
     if (carID >= race.nCars) return; // Trying to add lap to car not in race
 
     CarReference car = carRef(carID);
 
-    Timestamp timeNow = Timestamp.now();
+    DateTime timeNow = DateTime.now();
 
-    lapTime ??= (timeNow.millisecondsSinceEpoch -
-            car.currentLap.date.millisecondsSinceEpoch) ~/
-        10 /
-        100;
+    lapTime ??= timeNow.difference(car.currentLap.date);
 
     // Create new lap
     car.currentLap.lapTime = lapTime;
@@ -62,7 +59,7 @@ class RaceReference {
 
     CarReference car = carRef(carID);
 
-    Duration relTime = DateTime.now().difference(car.currentLap.date.toDate());
+    Duration relTime = DateTime.now().difference(car.currentLap.date);
 
     car.currentLap.speedHistory.add(SpeedEntry(relTime, speed));
   }

--- a/lib/firebase/speed_entry.dart
+++ b/lib/firebase/speed_entry.dart
@@ -1,0 +1,19 @@
+class SpeedEntry {
+  const SpeedEntry(this.time, this.speed);
+
+  /// The duration between the start of the race and when this entry was recorded.
+  final Duration time;
+
+  /// The speed recorded.
+  final double speed;
+
+  SpeedEntry.fromMapEntry(MapEntry<String, dynamic> entry)
+      : this(
+          Duration(milliseconds: int.parse(entry.key)),
+          entry.value,
+        );
+
+  MapEntry<String, dynamic> toMapEntry() {
+    return MapEntry<String, dynamic>("${time.inMilliseconds}", speed);
+  }
+}

--- a/lib/race_browser_screen/lap_viewer_screen.dart
+++ b/lib/race_browser_screen/lap_viewer_screen.dart
@@ -53,26 +53,48 @@ class LapViewerScreen extends StatelessWidget {
   }
 
   List<LineChartBarData> getChartData() {
+    int averageN = 10;
+
     return laps.entries.map((car) {
       var speedHist = car.value.speedHistory.entries.toList();
       speedHist.sort((a, b) => a.key.compareTo(b.key)); // Sort speed entries
 
-      return LineChartBarData(
-        isCurved: true,
-        dotData: FlDotData(show: false),
-        color: [
-          Colors.green,
-          Colors.purple,
-          Colors.orange,
-          Colors.grey,
-        ][car.key],
-        spots: speedHist.map((speedEntry) {
-          return FlSpot(
-            speedEntry.key.toDouble() / 1000,
-            speedEntry.value,
+      List<FlSpot> spots = []; // Points to plot for this car
+
+      int timeSum = 0;
+      double speedSum = 0;
+
+      /// How many entries have been summed for this point
+      /// Can't just assume [averageN] entries have been summed, since that doesn't apply to the first point
+      int entriesAdded = 0;
+      speedHist.asMap().forEach((index, speedEntry) {
+        speedSum += speedEntry.value;
+        timeSum += speedEntry.key;
+        entriesAdded++;
+        if (index % averageN == 0) {
+          spots.add(
+            FlSpot(
+              timeSum / entriesAdded / 1000,
+              speedSum / entriesAdded,
+            ),
           );
-        }).toList(),
-      );
+          // Reset variables
+          speedSum = 0;
+          timeSum = 0;
+          entriesAdded = 0;
+        }
+      });
+
+      return LineChartBarData(
+          isCurved: true,
+          dotData: FlDotData(show: true),
+          color: [
+            Colors.green,
+            Colors.purple,
+            Colors.orange,
+            Colors.grey,
+          ][car.key],
+          spots: spots);
     }).toList();
   }
 }

--- a/lib/race_browser_screen/lap_viewer_screen.dart
+++ b/lib/race_browser_screen/lap_viewer_screen.dart
@@ -1,6 +1,6 @@
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:marklin_bluetooth/firebase/lap.dart';
+import 'package:marklin_bluetooth/race_browser_screen/speed_plot.dart';
 
 /// Widget for displaying speed history for laps with the same number as a chart.
 class LapViewerScreen extends StatelessWidget {
@@ -34,67 +34,12 @@ class LapViewerScreen extends StatelessWidget {
             child: Card(
               child: Padding(
                 padding: const EdgeInsets.all(10.0),
-                child: LineChart(
-                  LineChartData(
-                    lineBarsData: getChartData(),
-                    minX: 0,
-                    minY: 0,
-                    maxY: 100,
-                    borderData: FlBorderData(show: false),
-                    titlesData: FlTitlesData(show: false),
-                  ),
-                ),
+                child: SpeedPlot(laps: laps),
               ),
             ),
           )
         ],
       ),
     );
-  }
-
-  List<LineChartBarData> getChartData() {
-    int averageN = 10;
-
-    return laps.entries.map((car) {
-      var speedHist = car.value.speedHistory.entries.toList();
-      speedHist.sort((a, b) => a.key.compareTo(b.key)); // Sort speed entries
-
-      List<FlSpot> spots = []; // Points to plot for this car
-
-      int timeSum = 0;
-      double speedSum = 0;
-
-      /// How many entries have been summed for this point
-      /// Can't just assume [averageN] entries have been summed, since that doesn't apply to the first point
-      int entriesAdded = 0;
-      speedHist.asMap().forEach((index, speedEntry) {
-        speedSum += speedEntry.value;
-        timeSum += speedEntry.key;
-        entriesAdded++;
-        if (index % averageN == 0) {
-          spots.add(
-            FlSpot(
-              timeSum / entriesAdded / 1000,
-              speedSum / entriesAdded,
-            ),
-          );
-          // Reset variables
-          speedSum = 0;
-          timeSum = 0;
-          entriesAdded = 0;
-        }
-      });
-
-      return LineChartBarData(
-          isCurved: true,
-          dotData: FlDotData(show: true),
-          color: [
-            Colors.green,
-            Colors.purple,
-            Colors.orange,
-            Colors.grey,
-          ][car.key],
-          spots: spots);
-    }).toList();
   }
 }

--- a/lib/race_browser_screen/race_viewer_screen.dart
+++ b/lib/race_browser_screen/race_viewer_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:marklin_bluetooth/firebase/lap.dart';
 import 'package:marklin_bluetooth/firebase/race.dart';
 import 'package:marklin_bluetooth/firebase/race_reference.dart';
-import 'package:marklin_bluetooth/race_browser_screen/lap_viewer_screen.dart';
 import 'package:marklin_bluetooth/utils.dart';
 import 'package:marklin_bluetooth/widgets.dart';
 import 'package:stream_transform/stream_transform.dart';
@@ -74,8 +73,9 @@ class RaceViewerScreen extends StatelessWidget {
         title: Row(
           mainAxisSize: MainAxisSize.max,
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children:
-              entry.value.values.map((lap) => Text("${lap.lapTime}")).toList(),
+          children: entry.value.values
+              .map((lap) => Text("${lap.lapTime.inMilliseconds / 1000}"))
+              .toList(),
         ),
         onTap: () {
           Navigator.of(context).pushNamed("/lap", arguments: entry);

--- a/lib/race_browser_screen/speed_plot.dart
+++ b/lib/race_browser_screen/speed_plot.dart
@@ -15,23 +15,60 @@ class SpeedPlot extends StatefulWidget {
 }
 
 class SpeedPlotState extends State<SpeedPlot> {
+  /// How many speed entries to average into each point on the plot.
+  int averageN = 10;
+
   @override
   Widget build(BuildContext context) {
-    return LineChart(
-      LineChartData(
-        lineBarsData: getChartData(),
-        minX: 0,
-        minY: 0,
-        maxY: 100,
-        borderData: FlBorderData(show: false),
-        titlesData: FlTitlesData(show: false),
-      ),
+    return Column(
+      children: [
+        Expanded(
+          child: LineChart(
+            LineChartData(
+              lineBarsData: getChartData(),
+              minX: 0,
+              minY: 0,
+              maxY: 100,
+              borderData: FlBorderData(show: false),
+              titlesData: FlTitlesData(show: false),
+            ),
+          ),
+        ),
+        const Divider(),
+        Row(
+          children: [
+            Expanded(
+              child: Slider(
+                value: averageN.toDouble(),
+                min: 1,
+                max: 25,
+                divisions: 24,
+                label: "$averageN",
+                onChanged: (value) => setState(() {
+                  averageN = value.toInt();
+                }),
+              ),
+            ),
+            const Padding(
+              padding: EdgeInsets.only(right: 10),
+              child: Tooltip(
+                triggerMode: TooltipTriggerMode.tap,
+                showDuration: Duration(seconds: 3),
+                preferBelow: false,
+                padding: EdgeInsets.all(10),
+                margin: EdgeInsets.all(10),
+                message:
+                    "How many speed entries to average into each point on the plot",
+                child: Icon(Icons.info_outline),
+              ),
+            ),
+          ],
+        ),
+      ],
     );
   }
 
   List<LineChartBarData> getChartData() {
-    int averageN = 10;
-
     return widget.laps.entries.map((car) {
       var speedHist = car.value.speedHistory.entries.toList();
       speedHist.sort((a, b) => a.key.compareTo(b.key)); // Sort speed entries
@@ -64,7 +101,7 @@ class SpeedPlotState extends State<SpeedPlot> {
 
       return LineChartBarData(
           isCurved: true,
-          dotData: FlDotData(show: true),
+          dotData: FlDotData(show: false),
           color: [
             Colors.green,
             Colors.purple,

--- a/lib/race_browser_screen/speed_plot.dart
+++ b/lib/race_browser_screen/speed_plot.dart
@@ -70,31 +70,31 @@ class SpeedPlotState extends State<SpeedPlot> {
 
   List<LineChartBarData> getChartData() {
     return widget.laps.entries.map((car) {
-      var speedHist = car.value.speedHistory.entries.toList();
-      speedHist.sort((a, b) => a.key.compareTo(b.key)); // Sort speed entries
+      var speedHist = car.value.speedHistory;
+      speedHist.sort((a, b) => a.time.compareTo(b.time)); // Sort speed entries
 
       List<FlSpot> spots = []; // Points to plot for this car
 
-      int timeSum = 0;
+      Duration timeSum = const Duration();
       double speedSum = 0;
 
       /// How many entries have been summed for this point
       /// Can't just assume [averageN] entries have been summed, since that doesn't apply to the first point
       int entriesAdded = 0;
       speedHist.asMap().forEach((index, speedEntry) {
-        speedSum += speedEntry.value;
-        timeSum += speedEntry.key;
+        speedSum += speedEntry.speed;
+        timeSum += speedEntry.time;
         entriesAdded++;
         if (index % averageN == 0) {
           spots.add(
             FlSpot(
-              timeSum / entriesAdded / 1000,
+              timeSum.inMilliseconds / entriesAdded / 1000,
               speedSum / entriesAdded,
             ),
           );
           // Reset variables
           speedSum = 0;
-          timeSum = 0;
+          timeSum = const Duration();
           entriesAdded = 0;
         }
       });

--- a/lib/race_browser_screen/speed_plot.dart
+++ b/lib/race_browser_screen/speed_plot.dart
@@ -1,0 +1,77 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:marklin_bluetooth/firebase/lap.dart';
+
+class SpeedPlot extends StatefulWidget {
+  const SpeedPlot({
+    Key? key,
+    required this.laps,
+  }) : super(key: key);
+
+  final Map<int, Lap> laps;
+
+  @override
+  State<StatefulWidget> createState() => SpeedPlotState();
+}
+
+class SpeedPlotState extends State<SpeedPlot> {
+  @override
+  Widget build(BuildContext context) {
+    return LineChart(
+      LineChartData(
+        lineBarsData: getChartData(),
+        minX: 0,
+        minY: 0,
+        maxY: 100,
+        borderData: FlBorderData(show: false),
+        titlesData: FlTitlesData(show: false),
+      ),
+    );
+  }
+
+  List<LineChartBarData> getChartData() {
+    int averageN = 10;
+
+    return widget.laps.entries.map((car) {
+      var speedHist = car.value.speedHistory.entries.toList();
+      speedHist.sort((a, b) => a.key.compareTo(b.key)); // Sort speed entries
+
+      List<FlSpot> spots = []; // Points to plot for this car
+
+      int timeSum = 0;
+      double speedSum = 0;
+
+      /// How many entries have been summed for this point
+      /// Can't just assume [averageN] entries have been summed, since that doesn't apply to the first point
+      int entriesAdded = 0;
+      speedHist.asMap().forEach((index, speedEntry) {
+        speedSum += speedEntry.value;
+        timeSum += speedEntry.key;
+        entriesAdded++;
+        if (index % averageN == 0) {
+          spots.add(
+            FlSpot(
+              timeSum / entriesAdded / 1000,
+              speedSum / entriesAdded,
+            ),
+          );
+          // Reset variables
+          speedSum = 0;
+          timeSum = 0;
+          entriesAdded = 0;
+        }
+      });
+
+      return LineChartBarData(
+          isCurved: true,
+          dotData: FlDotData(show: true),
+          color: [
+            Colors.green,
+            Colors.purple,
+            Colors.orange,
+            Colors.grey,
+          ][car.key],
+          spots: spots);
+    }).toList();
+  }
+}


### PR DESCRIPTION
Average speed during a few seconds when plotting
Fixes #22

How many entries should be averaged into each point on the plot can be changed using a slider.
Also make working with speed history easier by creating SpeedEntry class and preffering DateTime and Duration over Timestamp.